### PR TITLE
Downgrade ubuntu to have vagrant working, see #14

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(2) do |config|
         # But use 64bit for Docker demos, since it requires a 64bit host
         # Avoid https://atlas.hashicorp.com/ubuntu/ since those are notoriously broken
         #ubuntu.vm.box = "bento/ubuntu-18.04-i386"
-        ubuntu.vm.box = "bento/ubuntu-18.04"
+        ubuntu.vm.box = "bento/ubuntu-16.04"
 
         ubuntu.vm.hostname = "elastic-stack"
 


### PR DESCRIPTION
Latest commit https://github.com/xeraa/vagrant-elastic-stack/commit/b3d998e81592e576995bbf25935888fa8ab67fa0#diff-23b6f443c01ea2efcb4f36eedfea9089 updates VM to Ubuntu 18.04 but this prevents its creation.

See https://github.com/xeraa/vagrant-elastic-stack/issues/14.