### PR TITLE
Keep .sh files with unix EOL, see #15

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+*.sh    text eol=lf
+


### PR DESCRIPTION
Under Windows text files are checked out with Windows EOL, .sh files should be an exception since they're copied into the VM.

See https://github.com/xeraa/vagrant-elastic-stack/issues/15.